### PR TITLE
add support for ethereum account type and signature

### DIFF
--- a/model/accountType.proto
+++ b/model/accountType.proto
@@ -18,4 +18,5 @@ enum AccountType {
     BTCAccountType = 1;
     EmptyAccountType = 2; // To facilitate parsing transactions that allow empty account address
     EstoniaEidAccountType = 3; // Account type coming from Estonian eID
+    ETHAccountType = 4;
 }

--- a/model/escrow.proto
+++ b/model/escrow.proto
@@ -38,7 +38,7 @@ message Escrow {
     int64 Amount = 5 [ jstype = JS_STRING ];
     int64 Commission = 6 [ jstype = JS_STRING ];
     // Timeout is BlockHeight gap 
-    uint64 Timeout = 7 [ jstype = JS_STRING ];
+    int64 Timeout = 7 [ jstype = JS_STRING ];
     EscrowStatus Status = 8;
     uint32 BlockHeight = 9;
     bool Latest = 10;

--- a/model/signature.proto
+++ b/model/signature.proto
@@ -38,6 +38,8 @@ enum SignatureType {
     MultisigSignature = 2;
     // in bytes: []byte{3,0,0,0} for estonian eID validation purpose only
     EstoniaEidSignature = 3;
+    // in bytes: []byte{4,0,0,0}, eth uses ECDSA signing algorithm
+    EthereumSignature = 4;
 }
 
 // BitcoinPrivateKeyBytesLength represent the length of private key that can use


### PR DESCRIPTION
## Description
Add support for ethereum account and signature type

## Breakdown
- [x] add ethereum account type enum
- [x] add ethereum signature type enum

Related core PR https://github.com/zoobc/zoobc-core/pull/1459
